### PR TITLE
feat: update API authentification

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Records:
 ## Example
 
 ```go
-tr, _ := auroradns.NewTokenTransport("apiKey", "secretKey")
+tr, _ := auroradns.NewTokenTransport("apiKey", "secret")
 client, _ := auroradns.NewClient(tr.Client())
 
 zones, _, _ := client.GetZones()

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Records:
 ## Example
 
 ```go
-tr, _ := auroradns.NewTokenTransport("userID", "key")
+tr, _ := auroradns.NewTokenTransport("apiKey", "secretKey")
 client, _ := auroradns.NewClient(tr.Client())
 
 zones, _, _ := client.GetZones()
@@ -33,5 +33,4 @@ fmt.Println(zones)
 
 ## API Documentation
 
-- [API endpoint information](https://www.pcextreme.nl/community/d/111-what-is-the-api-endpoint-for-dns-health-checks)
 - [API docs](https://libcloud.readthedocs.io/en/latest/dns/drivers/auroradns.html#api-docs)

--- a/auth_test.go
+++ b/auth_test.go
@@ -11,27 +11,27 @@ import (
 
 func TestNewTokenTransport_success(t *testing.T) {
 	apiKey := "☺"
-	secretKey := "🔑"
+	secret := "🔑"
 
-	transport, err := NewTokenTransport(apiKey, secretKey)
+	transport, err := NewTokenTransport(apiKey, secret)
 	require.NoError(t, err)
 	assert.NotNil(t, transport)
 }
 
 func TestNewTokenTransport_missing_credentials(t *testing.T) {
 	apiKey := ""
-	secretKey := ""
+	secret := ""
 
-	transport, err := NewTokenTransport(apiKey, secretKey)
+	transport, err := NewTokenTransport(apiKey, secret)
 	require.Error(t, err)
 	assert.Nil(t, transport)
 }
 
 func TestTokenTransport_RoundTrip(t *testing.T) {
 	apiKey := "☺"
-	secretKey := "🔑"
+	secret := "🔑"
 
-	transport, err := NewTokenTransport(apiKey, secretKey)
+	transport, err := NewTokenTransport(apiKey, secret)
 	require.NoError(t, err)
 
 	req := httptest.NewRequest(http.MethodGet, "http://example.com", nil)

--- a/auth_test.go
+++ b/auth_test.go
@@ -10,28 +10,28 @@ import (
 )
 
 func TestNewTokenTransport_success(t *testing.T) {
-	userID := "☺"
-	key := "🔑"
+	apiKey := "☺"
+	secretKey := "🔑"
 
-	transport, err := NewTokenTransport(userID, key)
+	transport, err := NewTokenTransport(apiKey, secretKey)
 	require.NoError(t, err)
 	assert.NotNil(t, transport)
 }
 
 func TestNewTokenTransport_missing_credentials(t *testing.T) {
-	userID := ""
-	key := ""
+	apiKey := ""
+	secretKey := ""
 
-	transport, err := NewTokenTransport(userID, key)
+	transport, err := NewTokenTransport(apiKey, secretKey)
 	require.Error(t, err)
 	assert.Nil(t, transport)
 }
 
 func TestTokenTransport_RoundTrip(t *testing.T) {
-	userID := "☺"
-	key := "🔑"
+	apiKey := "☺"
+	secretKey := "🔑"
 
-	transport, err := NewTokenTransport(userID, key)
+	transport, err := NewTokenTransport(apiKey, secretKey)
 	require.NoError(t, err)
 
 	req := httptest.NewRequest(http.MethodGet, "http://example.com", nil)


### PR DESCRIPTION
The Aurora DNS API has been updated some time ago and no longer works with an `UserID`. It has been replaced with an API key, while the old key now communicates as a Secret Key. The [API documentation](https://libcloud.readthedocs.io/en/latest/dns/drivers/auroradns.html#api-docs) confirms this.

Usage as usual results in an AuthenticationFailedError.

```
Found DNS provider configured: auroradns
2022/06/30 14:38:04 [INFO] [example.com, *.example.com] acme: Obtaining SAN certificate
2022/06/30 14:38:04 [INFO] [*.example.com] AuthURL: https://acme-v02.api.letsencrypt.org/acme/authz-v3/125421786176
2022/06/30 14:38:04 [INFO] [example.com] AuthURL: https://acme-v02.api.letsencrypt.org/acme/authz-v3/125421786186
2022/06/30 14:38:04 [INFO] [*.example.com] acme: use dns-01 solver
2022/06/30 14:38:04 [INFO] [example.com] acme: Could not find solver for: tls-alpn-01
2022/06/30 14:38:04 [INFO] [example.com] acme: Could not find solver for: http-01
2022/06/30 14:38:04 [INFO] [example.com] acme: use dns-01 solver
2022/06/30 14:38:04 [INFO] [*.example.com] acme: Preparing to solve DNS-01
2022/06/30 14:38:04 [INFO] [example.com] acme: Preparing to solve DNS-01
2022/06/30 14:38:04 [INFO] [*.example.com] acme: Cleaning DNS-01 challenge
2022/06/30 14:38:04 [WARN] [*.example.com] acme: cleaning up failed: unknown recordID for "_acme-challenge.example.com." 
2022/06/30 14:38:04 [INFO] [example.com] acme: Cleaning DNS-01 challenge
2022/06/30 14:38:04 [WARN] [example.com] acme: cleaning up failed: unknown recordID for "_acme-challenge.example.com." 
2022/06/30 14:38:05 [INFO] Deactivating auth: https://acme-v02.api.letsencrypt.org/acme/authz-v3/125421786176
2022/06/30 14:38:05 [INFO] Deactivating auth: https://acme-v02.api.letsencrypt.org/acme/authz-v3/125421786186
2022/06/30 14:38:05 Could not obtain certificates:
	error: one or more domains had a problem:
[*.example.com] [*.example.com] acme: error presenting token: aurora: could not create record: AuthenticationFailedError - User 00000 was not found
[example.com] [example.com] acme: error presenting token: aurora: could not create record: AuthenticationFailedError - User 00000 was not found
Certificate generation failed.
```

As soon as I inserted my Api Key as `UserID` and my Secret Key as `key`, the certificate generation

```
LetsEncrypt request successful for:
*.example.com
example.com
```

This pull request fixes the wrong credential names to remove any confusion about its usage.